### PR TITLE
Add .WithStructRagSearchClient() extensiont to IKernelMemoryBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ using KernelMemory.StructRAG;
 
 var memory = new KernelMemoryBuilder()
     .WithOpenAIDefaults(Environment.GetEnvironmentVariable("OPENAI_API_KEY"))
-    .WithCustomSearchClient<StructRAGSearchCient>()
+    .WithStructRagSearchClient()
     .Build<MemoryServerless>();
 ```
 

--- a/sample/Program.cs
+++ b/sample/Program.cs
@@ -59,7 +59,7 @@ Console.WriteLine("====");
 Console.WriteLine($"Faithfulness: {await evaluation.Evaluate(answer, new Dictionary<string, object?>())}");
 
 var structRagMemory = memoryBuilder
-        .WithCustomSearchClient<StructRAGSearchCient>()
+        .WithStructRagSearchClient()
         .Build();
 
 answer = await memory.AskAsync(question);

--- a/sample/README.md
+++ b/sample/README.md
@@ -100,7 +100,7 @@ We can now do the same with StructRAG search client:
 
 ```cs
 var structRagMemory = memoryBuilder
-        .WithCustomSearchClient<StructRAGSearchCient>()
+        .WithStructRagSearchClient()
         .Build();
 
 answer = await memory.AskAsync(question);

--- a/src/KernelMemory.StructRAG/Extensions/IKernelMemoryBuilderExtension.cs
+++ b/src/KernelMemory.StructRAG/Extensions/IKernelMemoryBuilderExtension.cs
@@ -1,0 +1,13 @@
+﻿
+using KernelMemory.StructRAG;
+
+namespace Microsoft.KernelMemory;
+
+public static class IKernelMemoryBuilderExtension
+{
+    public static IKernelMemoryBuilder WithStructRagSearchClient(this IKernelMemoryBuilder builder)
+    {
+        return builder.WithCustomSearchClient<StructRAGSearchCient>();
+    }
+}
+


### PR DESCRIPTION
## Description

What's new?

- Add KernelMemoryBuilder extension to facilitate dependency injection of struct RAG search client.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other