### PR TITLE
fix wrong ikernelmemory used

### DIFF
--- a/sample/Program.cs
+++ b/sample/Program.cs
@@ -62,7 +62,7 @@ var structRagMemory = memoryBuilder
         .WithStructRagSearchClient()
         .Build();
 
-answer = await memory.AskAsync(question);
+answer = await structRagMemory.AskAsync(question);
 Console.WriteLine("StructRAG Memory Answer");
 Console.WriteLine(answer.Result);
 


### PR DESCRIPTION
## Description

What's new?

Fixed issue where the StructRag IKernelMemory was not used, producing unexpected results (apparent kernel memory being more precise than structrag) - StructRag IKernelMemory was created but not used.

original code:
```
var answer = await memory.AskAsync(question);

Console.WriteLine("Standard Kernel Memory Answer");
Console.WriteLine(answer.Result);

Console.WriteLine("====");
Console.WriteLine($"Faithfulness: {(await evaluation.EvaluateAsync(answer)).Score}");

var structRagMemory = memoryBuilder
        .WithStructRagSearchClient()
        .Build();

**answer = await memory.AskAsync(question);**
Console.WriteLine("StructRAG Memory Answer");
Console.WriteLine(answer.Result);

Console.WriteLine("====");
Console.WriteLine($"Faithfulness: {(await evaluation.EvaluateAsync(answer)).Score}");
```

updated code:
```
var answer = await memory.AskAsync(question);

Console.WriteLine("Standard Kernel Memory Answer");
Console.WriteLine(answer.Result);

Console.WriteLine("====");
Console.WriteLine($"Faithfulness: {(await evaluation.EvaluateAsync(answer)).Score}");

var structRagMemory = memoryBuilder
        .WithStructRagSearchClient()
        .Build();

**answer = await structRagMemory.AskAsync(question);**
Console.WriteLine("StructRAG Memory Answer");
Console.WriteLine(answer.Result);

Console.WriteLine("====");
Console.WriteLine($"Faithfulness: {(await evaluation.EvaluateAsync(answer)).Score}");
```
-

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other